### PR TITLE
Makefile + Markdown fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# List of ignored files
+# ---------------------
+
+# Build folders
+build
+
+# Vim/Emacs Artifacts
+.swp
+.temp
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,23 @@
+# Building VecFX
+
+Nominally, VecFX is included as part of Mo++, and is automatically compiled along with the rest of Mo++'s libraries. However, if you choose to work on it separately, you can compile it like so:
+
+## Getting the sources
+
+Make sure you have `pugixml` installed. You can find its installation instructions at [its website](https://pugixml.org/).
+
+Clone the repo from github:
+
+```
+git clone https://github.com/PhantomzBack/VecFX.git && cd VecFX
+```
+
+## Compiling
+
+From there, assuming you have `GNU make` and the `g++` compiler, all you need to do is
+
+```
+make
+```
+
+For any other compiling options, run `make help`, which will list all compiling options.

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,34 @@
 BUILDDIR = ./build/
-OBJS = SVGObject.o
-SOURCE = SVGObject.cpp
+OBJS = build/SVGObject.o build/main.o
+SOURCE = src/SVGObject.cpp src/main.cpp
+HEADER	= src/SVGObject.hpp
 LDLIBS += -lpugixml
+FLAGS = -c -Wall -static
+# -g option enables debugging mode 
+# -c flag generates object code for separate files
+# -Wall adds more warnings for debugging
 OUT = VecFX
 CC = g++
-INC= -I\include
+INCLUDE = -I./include/
 RM = /usr/bin/rm -rf
 MKDIR = /usr/bin/mkdir -p
 
 build: $(OBJS)
-	$(CC) -static $(BUILDDIR)$(OBJS) $(LDLIBS) -o $(BUILDDIR)$(OUT)
+	$(CC) -static -g $(OBJS) $(LDLIBS) -o $(BUILDDIR)$(OUT)
 	$(RM) $(BUILDDIR)*.o
 	chmod +x $(BUILDDIR)$(OUT)
 	@echo Build completed successfully!
 	@echo Executable located at $(BUILDDIR)$(OUT)
 
-SVGObject.o: $(SOURCE)
+build/SVGObject.o: src/SVGObject.cpp
+	@$(MKDIR) $(BUILDDIR)
+	@echo Build dir located at $(BUILDDIR)
+	$(CC) $(FLAGS) $(INC) src/SVGObject.cpp -o build/SVGObject.o
+
+build/main.o: src/main.cpp
 	@$(MKDIR) $(BUILDDIR)
 	@echo Build dir created at $(BUILDDIR)
-	$(CC) -c -Wall -static $(SOURCE) $(INC) -o $(BUILDDIR)$(OBJS)
+	$(CC) $(FLAGS) $(INC) src/main.cpp -o build/main.o
 
 clean:
 	$(RM) $(BUILDDIR)*.o

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,42 @@
-INC=-I\include
+BUILDDIR = ./build/
+OBJS = SVGObject.o
+SOURCE = SVGObject.cpp
+LDLIBS += -lpugixml
+OUT = VecFX
+CC = g++
+INC= -I\include
+RM = /usr/bin/rm -rf
+MKDIR = /usr/bin/mkdir -p
 
-application: SVGObject.o
-	g++ -static SVGObject.o -lpugixml -o VecFX && rm *.o && chmod +x VecFX && ./VecFX
+build: $(OBJS)
+	$(CC) -static $(BUILDDIR)$(OBJS) $(LDLIBS) -o $(BUILDDIR)$(OUT)
+	$(RM) $(BUILDDIR)*.o
+	chmod +x $(BUILDDIR)$(OUT)
+	@echo Build completed successfully!
+	@echo Executable located at $(BUILDDIR)$(OUT)
 
-SVGObject.o:
-	g++ -static -c SVGObject.cpp $(INC) -o  SVGObject.o
+SVGObject.o: $(SOURCE)
+	@$(MKDIR) $(BUILDDIR)
+	@echo Build dir created at $(BUILDDIR)
+	$(CC) -c -Wall -static $(SOURCE) $(INC) -o $(BUILDDIR)$(OBJS)
 
+clean:
+	$(RM) $(BUILDDIR)*.o
+	@echo Build cleaned!
 
+purge:
+	@echo Are you sure you want to clean everything?
+	@read -p "[Enter to confirm, CTRL C to stop]: "
+	$(RM) $(BUILDDIR)
 
+guide:
+	@echo -e "This is the VecFX compiling help guide:\n"
+	@cat BUILD.md
+help:
+	@echo Project options:
+	@echo -e "\t Build objects only: make SVGObject.o"
+	@echo -e "\t Build application (default): make build"
+	@echo -e "\t Clean build artifacts: make clean"
+	@echo -e "\t Clean entire build: make purge"
+	@echo -e "\t Show help (you're looking at it right now): make help"
+	@echo -e "\t For further help, run: make guide"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # VecFX
+
+VecFX is a versatile graphics engine that powers Mo++. It can be run as standalone software, but its default configuration is as the renderer of Mo++.
+
+To get started, see [build instructions](BUILD.md) and [documentation](docs/index.md).

--- a/src/SVGObject.cpp
+++ b/src/SVGObject.cpp
@@ -6,7 +6,7 @@
 #include <list>
 #include <algorithm>
 #include <time.h>
-#include "include/pugixml.hpp"
+#include "pugixml.hpp"
 #include "SVGObject.hpp"
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
## PR Description

- Revised Makefile to be more customizable and written more semantically
- Compiling is now to a `build/` folder by default, making it easier to separate compiled objects and executables from source code
- Added gitignore
- Added some documentation for building